### PR TITLE
added dev and prod urls to inventory, use that to determine app-url for CC pipeline

### DIFF
--- a/.pipeline-config.yaml
+++ b/.pipeline-config.yaml
@@ -157,7 +157,24 @@ dynamic-scan:
       echo "If you want to enable this stage, add 'opt-in-dynamic-scan' parameter to your pipeline with any value. Also, please add 'opt-in-dynamic-api-scan' to your pipeline with any value to have api scans running, and 'opt-in-dynamic-ui-scan' with any value to have ui scans running" >&2
     else
       if [[ "$(get_env pipeline_namespace)" == *"cc"* ]]; then
-        app_url=$(get_env app-url "")
+        source "${ONE_PIPELINE_PATH}"/tools/get_repo_params
+
+        INVENTORY_PATH="$(get_env inventory-path)"
+        INVENTORY_TOKEN_PATH="./inventory-token"
+        read -r INVENTORY_REPO_NAME INVENTORY_REPO_OWNER INVENTORY_SCM_TYPE INVENTORY_API_URL < <(get_repo_params "$(get_env INVENTORY_URL)" "$INVENTORY_TOKEN_PATH")
+
+        APP_ARTIFACTS=$(cocoa inventory get \
+          --entry="$(get_env app-name '')" \
+          --org="${INVENTORY_REPO_OWNER}" \
+          --repo="${INVENTORY_REPO_NAME}" \
+          --environment="$(get_env target-environment 'prod')" \
+          --git-provider="${INVENTORY_SCM_TYPE}" \
+          --git-token-path="${INVENTORY_TOKEN_PATH}" \
+          --git-api-url="${INVENTORY_API_URL}" \
+          --property="app_artifacts")
+
+        app_url=$(jq -r '.prod_app_url' <<< $APP_ARTIFACTS)
+
         if [[ -z "${app_url}" ]]; then
           echo "Please provide the app-url as the running application url. Recommended to use stage/test environment to run the Dynamic scan." >&2
           exit 1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -53,7 +53,8 @@ while read -r artifact; do
     APP_NAME="$(get_env app-name)"
     APP_ARTIFACTS=$(jq --null-input -c --arg name "${APP_NAME}" --arg tags "${tags}" \
       --arg ce_type "$(get_env code-engine-deployment-type "application")" \
-      '.name=$name | .tags=$tags | .code_engine_deployment_type=$ce_type')
+      --arg dev_app_url "$(get_env app-url "")" \
+      '.name=$name | .tags=$tags | .code_engine_deployment_type=$ce_type | .dev_app_url=$dev_app_url ')
 
     # Only keep image name (without namespace part and no tag or sha) for inventory name
     # Image name is remaining part after the repository and namespace and can contains /

--- a/scripts/roks/deploy.sh
+++ b/scripts/roks/deploy.sh
@@ -6,6 +6,8 @@ setProperty(){
   mv $3.tmp $3
 }
 
+source "${ONE_PIPELINE_PATH}"/tools/get_repo_params
+
 # create namespace using oc
 oc new-project ${IBMCLOUD_IKS_CLUSTER_NAMESPACE} || oc project ${IBMCLOUD_IKS_CLUSTER_NAMESPACE}
 
@@ -203,3 +205,49 @@ fi
 echo "Application URL: ${APPURL}"
 echo -n "${APPURL}" >../app-url
 set_env app-url "${APPURL}"
+
+# if in CD pipeline, add the app-url to the inventory entry.
+if [[ "$(get_env pipeline_namespace)" == *"cd"* ]]; then
+    INVENTORY_PATH="$(get_env inventory-path)"
+    DEPLOYMENT_DELTA_PATH="$(get_env deployment-delta-path)"
+    jq '.' "$DEPLOYMENT_DELTA_PATH"
+    for INVENTORY_ENTRY in $(jq -r '.[]' $DEPLOYMENT_DELTA_PATH); do
+        PROVENANCE=$(jq -r '.provenance' ${INVENTORY_PATH}/${INVENTORY_ENTRY})
+        APP_NAME=$(jq -r '.name' ${INVENTORY_PATH}/${INVENTORY_ENTRY})
+
+        APP_ARTIFACTS=$(jq --null-input -c \
+            --arg name "${APP_NAME}" \
+            --arg tags "$(jq -r '.app_artifacts.tags' ${INVENTORY_PATH}/${INVENTORY_ENTRY})" \
+            --arg ce_type "$(jq -r '.app_artifacts.code_engine_deployment_type' ${INVENTORY_PATH}/${INVENTORY_ENTRY})" \
+            --arg dev_app_url "$(jq -r '.app_artifacts.dev_app_url' ${INVENTORY_PATH}/${INVENTORY_ENTRY})" \
+            --arg prod_app_url "${APPLICATION_URL}" \
+            '.name=$name | .tags=$tags | .code_engine_deployment_type=$ce_type | .dev_app_url=$dev_app_url | .prod_app_url=$prod_app_url ')
+
+        INVENTORY_TOKEN_PATH="./inventory-token"
+        read -r INVENTORY_REPO_NAME INVENTORY_REPO_OWNER INVENTORY_SCM_TYPE INVENTORY_API_URL < <(get_repo_params "$(get_env INVENTORY_URL)" "$INVENTORY_TOKEN_PATH")
+
+        params=(
+            --repository-url="$(jq -r '.repository_url' ${INVENTORY_PATH}/${INVENTORY_ENTRY})"
+            --commit-sha="$(jq -r '.commit_sha' ${INVENTORY_PATH}/${INVENTORY_ENTRY})"
+            --version="$(jq -r '.version' ${INVENTORY_PATH}/${INVENTORY_ENTRY})"
+            --build-number="$(jq -r '.build_number' ${INVENTORY_PATH}/${INVENTORY_ENTRY})"
+            --pipeline-run-id="$(jq -r '.pipeline_run_id' ${INVENTORY_PATH}/${INVENTORY_ENTRY})"
+            --org="$INVENTORY_REPO_OWNER"
+            --repo="$INVENTORY_REPO_NAME"
+            --git-provider="$INVENTORY_SCM_TYPE"
+            --git-token-path="$INVENTORY_TOKEN_PATH"
+            --git-api-url="$INVENTORY_API_URL"
+        )
+
+        cocoa inventory add \
+          --artifact="${PROVENANCE}" \
+          --name="${APP_NAME}" \
+          --app-artifacts="${APP_ARTIFACTS}" \
+          --signature="$(jq -r '.signature' ${INVENTORY_PATH}/${INVENTORY_ENTRY})" \
+          --provenance="${PROVENANCE}" \
+          --sha256="$(jq -r '.sha256' ${INVENTORY_PATH}/${INVENTORY_ENTRY})" \
+          --type="$(jq -r '.type' ${INVENTORY_PATH}/${INVENTORY_ENTRY})" \
+          --environment="$(get_env target-environment)" \
+          "${params[@]}"
+    done
+fi


### PR DESCRIPTION
- Add dev_app_url to inventory on release
- Add prod_app_url to inventory when CD pipeline completes
- Pull inventory entry in CC pipeline, retrieve app url so we can perform dynamic scans from prod instance
- This will require some pipeline properties in CC, namely target-environment for inventory branch, and app-name for inventory entry. 