### PR TITLE
added route, fixed app url logic

### DIFF
--- a/deployment_os.yml
+++ b/deployment_os.yml
@@ -93,3 +93,21 @@ spec:
     targetPort: http
   tls:
     termination: edge
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: gen-ai-rag-sample-app-tls
+  namespace: gen-ai-rag-sample-app
+  labels:
+    app: gen-ai-rag-sample-app
+    ingress: ingress-public
+spec:
+  host: gen-ai-rag-sample-app-tls-dev.subdomain
+  to:
+    kind: Service
+    name: gen-ai-rag-sample-app
+  port:
+    targetPort: http
+  tls:
+    termination: edge

--- a/scripts/roks/deploy.sh
+++ b/scripts/roks/deploy.sh
@@ -58,62 +58,14 @@ fi
 yq write --doc "${SECRET_DOC_INDEX}" "${DEPLOYMENT_FILE}" "data[.dockerconfigjson]" "${REGISTRY_AUTH}" > "${TEMP_DEPLOYMENT_FILE}"
 mv "${TEMP_DEPLOYMENT_FILE}" "${DEPLOYMENT_FILE}"
 
+echo "Updating public route in the deployment file ${DEPLOYMENT_FILE}"
+PUBLIC_ROUTE_DOC_INDEX=$(yq read --doc "*" --tojson "$DEPLOYMENT_FILE" | jq -r 'to_entries | .[] | select(.value.spec.host | tostring | ascii_downcase=="gen-ai-rag-sample-app-tls-dev.subdomain") | .key')
+PUBLIC_INGRESS_SUBDOMAIN=$(get_env cluster_public_ingress_subdomain "")
+yq write --doc "${PUBLIC_ROUTE_DOC_INDEX}" "${DEPLOYMENT_FILE}" "spec.host" "gen-ai-rag-sample-app-tls-dev.${PUBLIC_INGRESS_SUBDOMAIN}" > "${TEMP_DEPLOYMENT_FILE}"
+mv "${TEMP_DEPLOYMENT_FILE}" "${DEPLOYMENT_FILE}"
+
 # For polyglot practice
 source $WORKSPACE/$PIPELINE_CONFIG_REPO_PATH/.env.deploy.sh
-
-echo "Cluster IP Service should be unique accross all the namespace, updating Cluster IP service name with namespace..."
-CIP_DOC_INDEX=$(yq read --doc "*" --tojson "$DEPLOYMENT_FILE" | jq -r 'to_entries | .[] | select(.value.spec.type=="ClusterIP" ) | .key')
-CIP_SERVICE_NAME=$(yq r --doc "$CIP_DOC_INDEX" "$DEPLOYMENT_FILE" metadata.name)
-CIP_SERVICE_NAME="${CIP_SERVICE_NAME}"-"${IBMCLOUD_IKS_CLUSTER_NAMESPACE}"
-yq write --doc "${CIP_DOC_INDEX}" "${DEPLOYMENT_FILE}" "metadata.name" "${CIP_SERVICE_NAME}" > "${TEMP_DEPLOYMENT_FILE}"
-mv "${TEMP_DEPLOYMENT_FILE}" "${DEPLOYMENT_FILE}"
-if [ "${CLUSTER_TYPE}" == "OPENSHIFT" ]; then
-  ROUTE_DOC_INDEX=$(yq read --doc "*" --tojson "$DEPLOYMENT_FILE" | jq -r 'to_entries | .[] | select(.value.kind | ascii_downcase=="route") | .key')
-  yq write --doc "${ROUTE_DOC_INDEX}" "${DEPLOYMENT_FILE}" "spec.to.name" "${CIP_SERVICE_NAME}" > "${TEMP_DEPLOYMENT_FILE}"
-  mv "${TEMP_DEPLOYMENT_FILE}" "${DEPLOYMENT_FILE}"
-fi
-
-INGRESS_DOC_INDEX=$(yq read --doc "*" --tojson "$DEPLOYMENT_FILE" | jq -r 'to_entries | .[] | select(.value.kind | ascii_downcase=="ingress") | .key')
-if [ -n "${INGRESS_DOC_INDEX}" ]; then
-  echo "Updating Cluster IP service name in the ingress in ${DEPLOYMENT_FILE}"
-  yq write --doc "${INGRESS_DOC_INDEX}" "${DEPLOYMENT_FILE}" "spec.rules[0].http.paths[*].backend.service.name" "${CIP_SERVICE_NAME}" > "${TEMP_DEPLOYMENT_FILE}"
-  mv "${TEMP_DEPLOYMENT_FILE}" "${DEPLOYMENT_FILE}"
-fi
-
-# Check if the cluster is paid IKS cluster. If yes then update the cluster domain name in place for the host name.
-CLUSTER_INGRESS_SUBDOMAIN=$(ibmcloud ks cluster get --cluster "${IBMCLOUD_IKS_CLUSTER_NAME}" --json | jq -r '.ingressHostname // .ingress.hostname' | cut -d, -f1)
-INGRESS_DOC_INDEX=$(yq read --doc "*" --tojson "$DEPLOYMENT_FILE" | jq -r 'to_entries | .[] | select(.value.kind | ascii_downcase=="ingress") | .key')
-if [ -n "${CLUSTER_INGRESS_SUBDOMAIN}" ] && [ "${KEEP_INGRESS_CUSTOM_DOMAIN}" != true ]; then
-  if [ -z "${INGRESS_DOC_INDEX}" ]; then
-    echo "No Kubernetes Ingress definition found in $DEPLOYMENT_FILE."
-  else
-    # Update ingress with cluster domain/secret information
-    # Look for ingress rule whith host contains the token "cluster-ingress-subdomain"
-    INGRESS_RULES_INDEX=$(yq r --doc "${INGRESS_DOC_INDEX}" --tojson "${DEPLOYMENT_FILE}" | jq '.spec.rules | to_entries | .[] | select( .value.host | contains("cluster-ingress-subdomain")) | .key')
-    if [ -n "${INGRESS_RULES_INDEX}" ]; then
-      INGRESS_RULE_HOST=$(yq r --doc "${INGRESS_DOC_INDEX}" "${DEPLOYMENT_FILE}" spec.rules["${INGRESS_RULES_INDEX}"].host)
-      DOMAIN_ADDRESS="${IBMCLOUD_IKS_CLUSTER_NAMESPACE}"."${CLUSTER_INGRESS_SUBDOMAIN}"
-      # IKS provides a valid TLS certificate for *.Cluster-ingress-sub-domian
-      # Update the host with format {App-Name}-{Cluster-Namespace}.{Cluster-ingress-subdomain}
-      # Example :- https://hello-app-prod.gen2phm-b-57a8db4f565402d4797cc1d3399c50e2-0000.eu-de.containers.appdomain.cloud/
-      # hello-app is from INGRESS_RULES_INDEX
-      # prod is cluster namespace
-      yq w --inplace --doc "${INGRESS_DOC_INDEX}" "${DEPLOYMENT_FILE}" spec.rules["${INGRESS_RULES_INDEX}"].host "${INGRESS_RULE_HOST/.cluster-ingress-subdomain/-$DOMAIN_ADDRESS}"
-    fi
-  fi
-fi
-
-CLUSTER_INGRESS_SECRET=$(ibmcloud ks cluster get --cluster "${IBMCLOUD_IKS_CLUSTER_NAME}" --json | jq -r '.ingressSecretName // .ingress.secretName' | cut -d, -f1 )
-if [ "${CLUSTER_TYPE}" == "OPENSHIFT" ]; then
-  ROUTE_DOC_INDEX=$(yq read --doc "*" --tojson "$DEPLOYMENT_FILE" | jq -r 'to_entries | .[] | select(.value.kind | ascii_downcase=="route") | .key')
-  if [ -n "$ROUTE_DOC_INDEX" ]; then
-    route_spec_tls="$(yq read --doc "${ROUTE_DOC_INDEX}" "${DEPLOYMENT_FILE}" spec.tls)"
-    if [ -z "$route_spec_tls" ] || [ "$route_spec_tls" == "null" ]; then
-      echo "Setting spec.tls in Route"
-      yq w --inplace --doc "${ROUTE_DOC_INDEX}" "${DEPLOYMENT_FILE}" spec.tls.termination "edge"
-    fi
-  fi
-fi
 
 # Portieris is not compatible with image name containing both tag and sha. Removing the tag
 IMAGE="${IMAGE#*"@"}"
@@ -141,61 +93,7 @@ if [ "$status" = failure ]; then
   exit 1
 fi
 
-export APPURL
-if [ "${CLUSTER_TYPE}" == "OPENSHIFT" ]; then
-  ROUTE_DOC_INDEX=$(yq read --doc "*" --tojson "$DEPLOYMENT_FILE" | jq -r 'to_entries | .[] | select(.value.kind | ascii_downcase=="route") | .key')
-  if [ -n "$ROUTE_DOC_INDEX" ]; then
-    route_name=$(yq r --doc "$ROUTE_DOC_INDEX" "$DEPLOYMENT_FILE" metadata.name)
-    route_json_file=$(mktemp)
-    kubectl get route --namespace "$IBMCLOUD_IKS_CLUSTER_NAMESPACE" "${route_name}" -o json > $route_json_file
-    route_host="$(jq -r '.spec.host//empty' "$route_json_file")"
-    route_path="$(jq -r '.spec.path//empty' "$route_json_file")"
-    # Remove the last / from selected_route_path if any
-    route_path="${route_path%/}"
-    if jq -e '.spec.tls' "$route_json_file" > /dev/null 2>&1; then
-      route_protocol="https"
-    else
-      route_protocol="http"
-    fi
-    APPURL="${route_protocol}://${route_host}${route_path}"
-  fi
-else
-  sleep 10
-  if [ -n "${CLUSTER_INGRESS_SUBDOMAIN}" ] && [ "${KEEP_INGRESS_CUSTOM_DOMAIN}" != true ]; then
-    if [ -z "$INGRESS_DOC_INDEX" ]; then
-      echo "No Kubernetes Ingress definition found in $DEPLOYMENT_FILE."
-    else
-      service_name=$(yq r --doc "$INGRESS_DOC_INDEX" "$DEPLOYMENT_FILE" metadata.name)
-      # shellcheck disable=SC2034
-      for ITER in {1..30}
-      do
-        INGRESS_JSON=$(kubectl get ingress --namespace "${IBMCLOUD_IKS_CLUSTER_NAMESPACE}" "${service_name}" -o json)
-        # Expose app using ingress host and path for the service
-        APP_HOST=$(echo "$INGRESS_JSON" | jq -r --arg service_name "${CIP_SERVICE_NAME}" '.spec.rules[] | first(select(.http.paths[].backend.serviceName==$service_name or .http.paths[].backend.service.name==$service_name)) | .host' | head -n1)
-        APP_PATH=$(echo "$INGRESS_JSON" | jq -r --arg service_name "${CIP_SERVICE_NAME}" '.spec.rules[].http.paths[] | first(select(.backend.serviceName==$service_name or .backend.service.name==$service_name)) | .path' | head -n1)
-        # Remove any group in the path in case of regex in ingress path definition
-        # https://kubernetes.github.io/ingress-nginx/user-guide/ingress-path-matching/
-        # shellcheck disable=SC2001
-        APP_PATH=$(echo "$APP_PATH" | sed "s/([^)]*)//g")
-        # Remove the last / from APP_PATH if any
-        APP_PATH="${APP_PATH%/}"
-        if [ -n  "${APP_HOST}"  ]; then
-          APPURL="https://${APP_HOST}""${APP_PATH}"
-          break
-        fi
-        sleep 2
-      done
-    fi
-  fi
-
-  # If unable to find the APP_URL and Ingress sub domain is not available.
-  if [ -z  "${APPURL}"  ] || [[  "${APPURL}" = "null"  ]]; then
-    service_name=$(yq r -d "${SERVICE_DOC_INDEX}" "${DEPLOYMENT_FILE}" metadata.name)
-    IP_ADDRESS=$(kubectl get nodes -o json | jq -r '[.items[] | .status.addresses[] | select(.type == "ExternalIP") | .address] | .[0]')
-    PORT=$(kubectl get service -n "$IBMCLOUD_IKS_CLUSTER_NAMESPACE" "$service_name" -o json | jq -r '.spec.ports[0].nodePort')
-    APPURL="http://${IP_ADDRESS}:${PORT}"
-  fi
-fi
+export APPURL="https://gen-ai-rag-sample-app-tls-dev.${PUBLIC_INGRESS_SUBDOMAIN}"
 
 if [ -z  "${APPURL}"  ] || [[  "${APPURL}" = "null"  ]] || [[  "${APPURL}" = ":"  ]]; then
     echo "Unable to get Application URL....."


### PR DESCRIPTION
- added route for public ingress
- added logic to populate the host of that route with pipeline property `cluster_public_ingress_subdomain`
- use that app url for dynamic scans
- remove old app url logic