### PR TITLE
Update docs for da v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
-# gen-ai-rag-watsonx-sample-application
-Sample application that uses generative AI RAG pattern. Deployment target on IBM Cloud and uses IBM watsonx.ai, watsonx Assistant and Watson Discovery services
+# Gen AI - Retrieval Augmented Generation (RAG) - Sample Application
+This sample application and data enables generative AI RAG pattern with watsonx Assistant.
+
+Use the [RAG Pattern deployable architecture](https://cloud.ibm.com/catalog/7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3/architecture/Retrieval_Augmented_Generation_Pattern-5fdd0045-30fc-4013-a8bc-6db9d5447a52-global) to deploy it to IBM Cloud Code Engine or RedHat OpenShift.
+
+The deployable architecture also deploys and configures the relevant generative AI RAG services (watsonx.ai, watsonx Assistant), data (Elasticsearch), and other supporting services for logging, monitoring, security and compliance. The configurations are flexible and can be changed to meet the needs for several types of RAG patterns depending on the chosen combination of technologies and services. 

--- a/artifacts/artifacts-README.md
+++ b/artifacts/artifacts-README.md
@@ -1,5 +1,19 @@
 ## Configuration steps for watsonx Assistant artifacts
 
+
+The latest v2.0.0 of the [RAG Pattern deployable architecture](
+https://cloud.ibm.com/catalog/7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3/architecture/Retrieval_Augmented_Generation_Pattern-5fdd0045-30fc-4013-a8bc-6db9d5447a52-global) does not require any manual steps to configure watsonx Assistant. The deployable architecure automatically adds action and search skill to watsonx Assistant and configures Conversational Search with the provisioned Elasticsearch credentials and a keyword index of the sample data.
+
+Follow the steps [here](https://github.com/terraform-ibm-modules/stack-retrieval-augmented-generation/blob/main/README.md#monitor-the-build-and-application-deployment) to monitor the deployment and launch the sample application.
+
+
+---
+
+
+Configurations steps for v1.x of [RAG Pattern deployable architecture](
+https://cloud.ibm.com/catalog/7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3/architecture/Retrieval_Augmented_Generation_Pattern-5fdd0045-30fc-4013-a8bc-6db9d5447a52-global) are provided below.
+
+
 The *Gen AI Sample Application* requires configurations on watsonx Assistant to enable integration with Watson Discovery (for content search) and watsonx.ai (for generative ai tasks).
 
 Follow the steps below to configure watsonx Assistant.
@@ -204,5 +218,3 @@ Ask the question:
 Response to the question confirms successful integration of watsonx Assistant with Watson Discovery and watsonx.ai.
 
 **This completes the watsonx Assistant artifact configuration.**
-
-

--- a/artifacts/artifacts-cleanup.md
+++ b/artifacts/artifacts-cleanup.md
@@ -1,5 +1,23 @@
 ## Removing the watsonx Assistant artifacts
 
+Steps to remove deployments and configurations made by v2.0.0 of the [RAG Pattern deployable architecture](
+https://cloud.ibm.com/catalog/7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3/architecture/Retrieval_Augmented_Generation_Pattern-5fdd0045-30fc-4013-a8bc-6db9d5447a52-global):
+
+Undeploying the "Gen AI - WatsonX SaaS services" from the RAG Deployable Architecture Stack will remove the watsonx Assistant and all the artifacts that were added manually. It will also remove other watsonx instances. To remove watsonx Assistant artifacts individually, launch watsonx Assistant UI, select your gen-ai-rag-sample-app-assistant Assistant workspace and follow the cleanup options below.
+
+__Removing Actions and Variables only__
+
+To remove the Actions and Variables created from the Actions import JSON, navigate Home>Actions> All items>Created by you and Navigate Home>Actions> Variables>Created by you and delete each entry manually. The Assistant's workspace IDs will remain same and sample application will continue to use this Assistant. You can create your own Actions and Variables or reimport the Actions JSON file if needed.
+
+__Removing Assistant workspace__
+
+To fully remove the Assistant workspace, Navigate left bottom menu to Assistant settings>Delete assistant. Note that you will need to "Deploy again" the Deployable Architecture - Workload - Sample RAG App Configuration". This will create a new Assistant and redeploy the sample application with IDs of the new Assistant.
+
+---
+
+Steps to remove deployments and configurations made by v1.x of the [RAG Pattern deployable architecture](
+https://cloud.ibm.com/catalog/7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3/architecture/Retrieval_Augmented_Generation_Pattern-5fdd0045-30fc-4013-a8bc-6db9d5447a52-global):
+
 Undeploying the "4 - WatsonX SaaS services" from the RAG Deployable Architecture Stack will remove the watsonx Assistant and all the artifacts that were added manually. It will also remove other watsonx instances. To remove watsonx Assistant artifacts individually, launch watsonx Assistant UI, select gen-ai-rag-sample-v1 Assistant workspace and follow the cleanup options below.
 
 __Removing Custom Extensions only__


### PR DESCRIPTION
Updated description in readme and provided a link to the RAG deployable architecture v2.