### PR TITLE
fix: disable service account token automount in deployment

### DIFF
--- a/deployment_os.yml
+++ b/deployment_os.yml
@@ -43,6 +43,7 @@ spec:
         app: gen-ai-rag-sample-app
     spec:
       serviceAccountName: gen-ai-rag-sample-app-sa
+      automountServiceAccountToken: false
       containers:
         - name: gen-ai-rag-sample-app
           image: gen-ai-rag-sample-app


### PR DESCRIPTION
Fix Sonar Kubernetes security issue by disabling service account token mounting

```
[
  {
    "message": "Bind this Service Account to RBAC or disable \"automountServiceAccountToken\".",
    "componentName": "dev-9rmy-app-repo-compliance-check:deployment_os.yml",
    "timeStamp": {
      "creationDate": "2024-08-26T12:48:45+0000",
      "updateDate": "2025-12-04T13:13:52+0000"
    },
    "textRange": {
      "startLine": 45,
      "endLine": 45,
      "startOffset": 26,
      "endOffset": 50
    }
  }
]
```

[GitHub Issue](https://github.com/terraform-ibm-modules/stack-ibm-retrieval-augmented-generation/issues/282)